### PR TITLE
Post location gps merge to develop_4 branch

### DIFF
--- a/Foolog/app/src/main/AndroidManifest.xml
+++ b/Foolog/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <!-- 사용자 위치정보 접근 권한 설정 부여 -->
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
     <application
         android:allowBackup="true"

--- a/Foolog/app/src/main/java/fastcampus/team1/foolog/Map/GpsInfo.java
+++ b/Foolog/app/src/main/java/fastcampus/team1/foolog/Map/GpsInfo.java
@@ -1,0 +1,220 @@
+package fastcampus.team1.foolog.Map;
+
+import android.Manifest;
+import android.app.Service;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.provider.Settings;
+import android.support.annotation.Nullable;
+import android.support.v4.app.ActivityCompat;
+import android.support.v7.app.AlertDialog;
+
+/**
+ * Created by SeungHoShin on 2017. 8. 11..
+ */
+
+public class GpsInfo extends Service implements LocationListener {
+
+
+    private final Context mContext;
+
+    // 현재 GPS 사용유무
+    boolean isGPSEnabled = false;
+
+    // 네트워크 사용유무
+    boolean isNetworkEnabled = false;
+
+    // GPS 상태값
+    boolean isGetLocation = false;
+
+    Location location;
+    private double latitude;
+    private double longitude;
+
+    // 최소 GPS 정보 업데이트 거리 10미터
+    private static final long MIN_DISTANCE_CHANGE_FOR_UPDATES = 10;
+
+    // 최소 GPS 정보 업데이트 시간 밀리세컨이므로 1분
+    private static final long MIN_TIME_BW_UPDATES = 1000 * 60 * 1;
+
+    protected LocationManager locationManager;
+
+
+    public GpsInfo(Context context) {
+        this.mContext = context;
+        getLocation(mContext);
+    }
+
+
+    public Location getLocation(Context mContext) {
+
+
+        try {
+            locationManager = (LocationManager) mContext
+                    .getSystemService(LOCATION_SERVICE);
+
+            // GPS 정보 가져오기
+            isGPSEnabled = locationManager
+                    .isProviderEnabled(LocationManager.GPS_PROVIDER);
+
+            // 현재 네트워크 상태 값 알아오기
+            isNetworkEnabled = locationManager
+                    .isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+
+            if (!isGPSEnabled && !isNetworkEnabled) {
+                // GPS 와 네트워크사용이 가능하지 않을때 소스 구현
+            } else {
+                this.isGetLocation = true;
+                // 네트워크 정보로 부터 위치값 가져오기
+                if (isNetworkEnabled) {
+                    // todo 권한처리 작동처리
+
+
+                        locationManager.requestLocationUpdates(
+                                LocationManager.NETWORK_PROVIDER,
+                                MIN_TIME_BW_UPDATES,
+                                MIN_DISTANCE_CHANGE_FOR_UPDATES, this);
+
+                        if (locationManager != null) {
+                            location = locationManager
+                                    .getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
+                            if (location != null) {
+                                // 위도 경도 저장
+                                latitude = location.getLatitude();
+                                longitude = location.getLongitude();
+                            }
+                        }
+                    }
+
+
+                    if (isGPSEnabled) {
+                        if (location == null) {
+                            locationManager.requestLocationUpdates(
+                                    LocationManager.GPS_PROVIDER,
+                                    MIN_TIME_BW_UPDATES,
+                                    MIN_DISTANCE_CHANGE_FOR_UPDATES, this);
+                            if (locationManager != null) {
+                                location = locationManager
+                                        .getLastKnownLocation(LocationManager.GPS_PROVIDER);
+                                if (location != null) {
+                                    latitude = location.getLatitude();
+                                    longitude = location.getLongitude();
+                                }
+                            }
+                        }
+                    }
+                }
+
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) !=
+                    PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(this,
+                    Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            }
+        }
+        return location;
+    }
+
+
+    /**
+     * GPS 종료
+     */
+    public void stopUsingGPS() {
+        if (locationManager != null) {
+            locationManager.removeUpdates(GpsInfo.this);
+        }
+    }
+
+    /**
+     * 위도값을 가져옵니다.
+     */
+    public double getLatitude() {
+        if (location != null) {
+            latitude = location.getLatitude();
+        }
+        return latitude;
+    }
+
+    /**
+     * 경도값을 가져옵니다.
+     */
+    public double getLongitude() {
+        if (location != null) {
+            longitude = location.getLongitude();
+        }
+        return longitude;
+    }
+
+    /**
+     * GPS 나 wifi 정보가 켜져있는지 확인합니다.
+     */
+    public boolean isGetLocation() {
+        return this.isGetLocation;
+    }
+
+    /**
+     * GPS 정보를 가져오지 못했을때
+     * 설정값으로 갈지 물어보는 alert 창
+     */
+    public void showSettingsAlert() {
+        AlertDialog.Builder alertDialog = new AlertDialog.Builder(mContext);
+
+        alertDialog.setTitle("GPS 사용유무셋팅");
+        alertDialog.setMessage("GPS 셋팅이 되지 않았을수도 있습니다.\n 설정창으로 가시겠습니까?");
+
+        // OK 를 누르게 되면 설정창으로 이동합니다.
+        alertDialog.setPositiveButton("Settings",
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        Intent intent = new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS);
+                        mContext.startActivity(intent);
+                    }
+                });
+        // Cancle 하면 종료 합니다.
+        alertDialog.setNegativeButton("Cancel",
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.cancel();
+                    }
+                });
+
+        alertDialog.show();
+    }
+
+
+    // 서비스에 관한 함수
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    // LocationListener에 관한 함수
+    @Override
+    public void onLocationChanged(Location location) {
+
+    }
+
+    @Override
+    public void onStatusChanged(String s, int i, Bundle bundle) {
+
+    }
+
+    @Override
+    public void onProviderEnabled(String s) {
+
+    }
+
+    @Override
+    public void onProviderDisabled(String s) {
+
+    }
+}

--- a/Foolog/app/src/main/java/fastcampus/team1/foolog/WriteActivity.java
+++ b/Foolog/app/src/main/java/fastcampus/team1/foolog/WriteActivity.java
@@ -205,7 +205,6 @@ public class WriteActivity extends AppCompatActivity implements View.OnClickList
                             latitude = (float) gps.getLatitude();
                             longitude = (float) gps.getLongitude();
                             Log.e("WriteActivity", "GPS이용한 위도추출==" + latitude + "경도추출===" + longitude);
-                            Toast.makeText(this,"당신의 위치 - \n위도: " + latitude + "\n경도: " + longitude,Toast.LENGTH_SHORT).show();
                         } else {
                             gps.showSettingsAlert();
                         }
@@ -254,7 +253,10 @@ public class WriteActivity extends AppCompatActivity implements View.OnClickList
         if (list != null) {
             Log.e("WriteActivity", "geocoder list3===" + list);
             if (list.size() == 0) {
-                txtAdress.setText("사진의 위치정보 값이 없어 현재위치 또는 마지막위치가 저장됩니다.");
+                if (gps.getLatitude()==0){
+                    txtAdress.setText("GPS를 활성화해 위치정보를 받아오세요. \n GPS를 키신 경우 사진을 다시 선택해주세요.");
+                    Toast.makeText(this,"만약 위치정보를 등록을 안하시면 \n 마커의 등록이 안됩니다.",Toast.LENGTH_LONG).show();
+                }
             } else {
                 txtAdress.setText(list.get(0).getAddressLine(0).toString());
                 Log.e("WriteActivity", "list.get(0).getAddressLine(0).toString()==" + list.get(0).getAddressLine(0).toString());

--- a/Foolog/app/src/main/java/fastcampus/team1/foolog/WriteActivity.java
+++ b/Foolog/app/src/main/java/fastcampus/team1/foolog/WriteActivity.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.List;
 
 import fastcampus.team1.foolog.Map.GeoDegree;
+import fastcampus.team1.foolog.Map.GpsInfo;
 import fastcampus.team1.foolog.model.WriteListResult;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
@@ -85,6 +86,7 @@ public class WriteActivity extends AppCompatActivity implements View.OnClickList
     String set_latitude;
     String set_longitude;
 
+    private GpsInfo gps;
 
 
     @Override
@@ -95,6 +97,7 @@ public class WriteActivity extends AppCompatActivity implements View.OnClickList
         initView();
         setListener();
         setRadioGroup();
+
     }
 
     /**
@@ -195,17 +198,31 @@ public class WriteActivity extends AppCompatActivity implements View.OnClickList
                     // todo 만약의 사진의 위치정보 값이 없으면 자기 현재의 위치 or 마지막 위치의 정보값을 저장하게 만든다
                     ExifInterface exif = new ExifInterface(imagePath);
                     GeoDegree geoDegree = new GeoDegree(exif);
-                    latitude = geoDegree.getLatitude();
-                    longitude = geoDegree.getLongitude();
+                    if (geoDegree.getLatitude() == null) {
+                        gps = new GpsInfo(WriteActivity.this);
+                        //GPS 사용유무 가져오기
+                        if (gps.isGetLocation()) {
+                            latitude = (float) gps.getLatitude();
+                            longitude = (float) gps.getLongitude();
+                            Log.e("WriteActivity", "GPS이용한 위도추출==" + latitude + "경도추출===" + longitude);
+                            Toast.makeText(this,"당신의 위치 - \n위도: " + latitude + "\n경도: " + longitude,Toast.LENGTH_SHORT).show();
+                        } else {
+                            gps.showSettingsAlert();
+                        }
+                    } else {
+                        latitude = geoDegree.getLatitude();
+                        longitude = geoDegree.getLongitude();
+                    }
                     setLocation();
-                    Log.e("WriteActivity","latitude==="+latitude);
-                    Log.e("WriteActivity","longitude==="+longitude);
+                    //gps.stopUsingGPS();
+                    Log.e("WriteActivity", "latitude===" + latitude);
+                    Log.e("WriteActivity", "longitude===" + longitude);
 
-                    Log.e("WriteActivity","DATETIME==="+exif.getAttribute(ExifInterface.TAG_DATETIME));
-                    Log.e("WriteActivity","Longtitude REF==="+exif.getAttribute(ExifInterface.TAG_GPS_LONGITUDE_REF));
-                    Log.e("WriteActivity","Longtitude ==="+exif.getAttribute(ExifInterface.TAG_GPS_LONGITUDE));
-                    Log.e("WriteActivity","Latitude REF==="+exif.getAttribute(ExifInterface.TAG_GPS_LATITUDE_REF));
-                    Log.e("WriteActivity","Latitude ==="+exif.getAttribute(ExifInterface.TAG_GPS_LATITUDE));
+                    Log.e("WriteActivity", "DATETIME===" + exif.getAttribute(ExifInterface.TAG_DATETIME));
+                    Log.e("WriteActivity", "Longtitude REF===" + exif.getAttribute(ExifInterface.TAG_GPS_LONGITUDE_REF));
+                    Log.e("WriteActivity", "Longtitude ===" + exif.getAttribute(ExifInterface.TAG_GPS_LONGITUDE));
+                    Log.e("WriteActivity", "Latitude REF===" + exif.getAttribute(ExifInterface.TAG_GPS_LATITUDE_REF));
+                    Log.e("WriteActivity", "Latitude ===" + exif.getAttribute(ExifInterface.TAG_GPS_LATITUDE));
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -227,20 +244,20 @@ public class WriteActivity extends AppCompatActivity implements View.OnClickList
         List<Address> list = null;
 
         try {
-            list = geocoder.getFromLocation(latitude,longitude,1);
-            Log.e("WriteActivity","geocoder list1==="+list);
+            list = geocoder.getFromLocation(latitude, longitude, 1);
+            Log.e("WriteActivity", "geocoder list1===" + list);
         } catch (IOException e) {
             e.printStackTrace();
-            Log.e("WriteActivity","GeoCoder 입출력 오류 - 서버에서 주소변환시 에러발생===");
+            Log.e("WriteActivity", "GeoCoder 입출력 오류 - 서버에서 주소변환시 에러발생===");
         }
-        Log.e("WriteActivity","geocoder list2==="+list);
-        if (list != null){
-            Log.e("WriteActivity","geocoder list3==="+list);
-            if (list.size()==0){
-                txtAdress.setText("해당되는 주소가 없습니다.(마커는 찍힙니다)");
-            }else {
+        Log.e("WriteActivity", "geocoder list2===" + list);
+        if (list != null) {
+            Log.e("WriteActivity", "geocoder list3===" + list);
+            if (list.size() == 0) {
+                txtAdress.setText("사진의 위치정보 값이 없어 현재위치 또는 마지막위치가 저장됩니다.");
+            } else {
                 txtAdress.setText(list.get(0).getAddressLine(0).toString());
-                Log.e("WriteActivity","list.get(0).getAddressLine(0).toString()=="+list.get(0).getAddressLine(0).toString());
+                Log.e("WriteActivity", "list.get(0).getAddressLine(0).toString()==" + list.get(0).getAddressLine(0).toString());
             }
         }
     }
@@ -248,9 +265,9 @@ public class WriteActivity extends AppCompatActivity implements View.OnClickList
     /**
      * 추출한 위도 경도 값을 서버로 통신을 하기 위해 String값으로 변환해주는 함수
      */
-    public void setLocation(){
-        set_latitude = ""+latitude;
-        set_longitude = ""+longitude;
+    public void setLocation() {
+        set_latitude = "" + latitude;
+        set_longitude = "" + longitude;
     }
 
 
@@ -411,7 +428,7 @@ public class WriteActivity extends AppCompatActivity implements View.OnClickList
         RequestBody latitude = RequestBody.create(MediaType.parse("text/plain"), set_latitude);
         RequestBody longitude = RequestBody.create(MediaType.parse("text/plain"), set_longitude);
 
-        Call<WriteListResult> call = service.uploadImage(send_token, photo, text, tags, title, memo, latitude,longitude);
+        Call<WriteListResult> call = service.uploadImage(send_token, photo, text, tags, title, memo, latitude, longitude);
         call.enqueue(new Callback<WriteListResult>() {
             @Override
             public void onResponse(Call<WriteListResult> call, Response<WriteListResult> response) {

--- a/Foolog/app/src/main/java/fastcampus/team1/foolog/WriteActivity.java
+++ b/Foolog/app/src/main/java/fastcampus/team1/foolog/WriteActivity.java
@@ -204,6 +204,7 @@ public class WriteActivity extends AppCompatActivity implements View.OnClickList
                         if (gps.isGetLocation()) {
                             latitude = (float) gps.getLatitude();
                             longitude = (float) gps.getLongitude();
+                            Toast.makeText(this,"사진의 위치정보값이 없어 현재위치를 불러옵니다.",Toast.LENGTH_LONG).show();
                             Log.e("WriteActivity", "GPS이용한 위도추출==" + latitude + "경도추출===" + longitude);
                         } else {
                             gps.showSettingsAlert();

--- a/Foolog/app/src/main/java/fastcampus/team1/foolog/iService.java
+++ b/Foolog/app/src/main/java/fastcampus/team1/foolog/iService.java
@@ -10,12 +10,12 @@ import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.GET;
 import retrofit2.http.Header;
 import retrofit2.http.Multipart;
 import retrofit2.http.POST;
 import retrofit2.http.Part;
 import retrofit2.http.Path;
-import retrofit2.http.Query;
 
 /**
  * Created by jhjun on 2017-08-01.

--- a/Foolog/app/src/main/java/fastcampus/team1/foolog/util/PermissionControl.java
+++ b/Foolog/app/src/main/java/fastcampus/team1/foolog/util/PermissionControl.java
@@ -21,9 +21,9 @@ public class PermissionControl {
 
     private static String permissions[] = {
             Manifest.permission.ACCESS_FINE_LOCATION,
-            Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
             Manifest.permission.INTERNET,
-            Manifest.permission.ACCESS_FINE_LOCATION
+            Manifest.permission.WRITE_EXTERNAL_STORAGE
     };
 
 


### PR DESCRIPTION
이미지의 EXIF(위도,경도)값이 없을 경우 GPS를 이용한 위치 받기
- GPS를 이용해서 현재위치의 값을 받아온다 
- 권한 추가

GPS 미 실행 시 텍스트 문구 변경

- "사진의 위치정보 값이 없어 현재위치 또는 마지막위치가 저장됩니다."
- -> "GPS를 활성화해 위치정보를 받아오세요. \n GPS를 키신 경우 사진을 다시 선택해주세요."
- -> Toast 추가 "만약 위치정보를 등록을 안하시면 \n 마커의 등록이 안됩니다."

GPS를 이용한 위도 경도값을 Toast로 나타냄.

- -> 삭제